### PR TITLE
dockerized neo4j with docker compose - add dataset in /cypher first

### DIFF
--- a/app/services/cypher_generator.py
+++ b/app/services/cypher_generator.py
@@ -1,6 +1,5 @@
 from typing import List
 import logging
-from dotenv import load_dotenv
 import neo4j
 from app.services.query_generator_interface import QueryGeneratorInterface
 from neo4j import GraphDatabase
@@ -8,8 +7,7 @@ import glob
 import os
 import json
 from neo4j.graph import Node, Relationship
-
-load_dotenv()
+logging.getLogger('neo4j').setLevel(logging.WARNING)
 
 class CypherQueryGenerator(QueryGeneratorInterface):
     def __init__(self, dataset_path: str):
@@ -17,8 +15,8 @@ class CypherQueryGenerator(QueryGeneratorInterface):
             os.getenv('NEO4J_URI'),
             auth=(os.getenv('NEO4J_USERNAME'), os.getenv('NEO4J_PASSWORD'))
         )
-        # self.dataset_path = dataset_path
-        # self.load_dataset(self.dataset_path)
+        self.dataset_path = dataset_path
+        self.load_dataset(self.dataset_path)
 
     def close(self):
         self.driver.close()
@@ -42,7 +40,7 @@ class CypherQueryGenerator(QueryGeneratorInterface):
                 with open(node_path, 'r') as file:
                     data = file.read()
                     for line in data.splitlines():
-                        self.run_query(line)
+                        self.run_query([line])
             except Exception as e:
                 print(f"Error loading dataset from '{node_path}': {e}")
 
@@ -53,7 +51,7 @@ class CypherQueryGenerator(QueryGeneratorInterface):
                 with open(edge_path, 'r') as file:
                     data = file.read()
                     for line in data.splitlines():
-                        self.run_query(line)
+                        self.run_query([line])
             except Exception as e:
                 print(f"Error loading dataset from '{edge_path}': {e}")
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,51 @@
+version: '3.8'
+services:
+  neo4j:
+    image: neo4j:5.22.0
+    ports:
+      - "7474:7474"
+      - "7687:7687"
+    # restart: always
+    volumes:
+      - neo4jdata:/var/lib/neo4j
+      - neo4jlogs:/var/log/neo4j
+      - neo4jimport:/var/lib/neo4j/import
+      - neo4jplugins:/var/lib/neo4j/plugins
+      - neo4jconf:/var/lib/neo4j/conf
+    
+    environment:
+      NEO4J_AUTH: neo4j/rejuvebio
+      NEO4J_server_bolt_enabled: true
+      NEO4J_PLUGINS: '["apoc"]'
+      NEO4J_dbms_security_procedures_unrestricted: "apoc.*"
+      NEO4J_dbms_security_procedures_whitelist: "apoc.*"
+      NEO4J_dbms_security_procedures_allowlist: "apoc.*"
+      NEO4J_apoc_export_file_enabled: true
+      NEO4J_apoc_import_file_enabled: true
+      NEO4J_apoc_import_file_use__neo4j__config: true
+      
+    healthcheck:
+      test: ["CMD-SHELL", "cypher-shell -u neo4j -p rejuvebio 'RETURN 1'"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
+  app:
+    build: .
+    ports:
+      - "5000:5000"
+    depends_on:
+      neo4j:
+        condition: service_healthy
+    environment:
+      NEO4J_URI: "bolt://neo4j:7687"
+      NEO4J_USERNAME: neo4j
+      NEO4J_PASSWORD: rejuvebio
+
+volumes:
+  neo4jdata:
+  neo4jlogs:
+  neo4jimport:
+  neo4jplugins:
+  neo4jconf:
+  


### PR DESCRIPTION
# Setup
 - add dataset in cypher datasets in /cypher directory 
 - optionally add metta dataset in /dataset ( /dataset required if metta generator is initialized in app/__init__.py databases otherwise will throw error  ValueError: Dataset path './dataset' does not exist.
# Command
run  docker compose up --build

# Other Changes and Fixes
 - in load_dataset, wrap query line in brackets because run query expects a list
     - previous: `for line in data.splitlines(): self.run_query(line)`
     - now: `for line in data.splitlines(): self.run_query([line])`
  - remove load_dotenv in cypher query generator that was used for getting environment variables like `os.getenv('NEO4J_URI')` , but we use docker compose environment to define the variables and not a .env file.